### PR TITLE
Fix reset of buffer options

### DIFF
--- a/plugin/mercenary.vim
+++ b/plugin/mercenary.vim
@@ -213,7 +213,7 @@ endfunction
 
 augroup mercenary_buffer
   autocmd!
-  autocmd BufWinLeave * call s:Buffer_winleave(expand('<abuf>'))
+  autocmd BufWinLeave * call s:Buffer_winleave(str2nr(expand('<abuf>')))
 augroup END
 
 " }}}1


### PR DESCRIPTION
Currently, the `scrollbind` option is not reset when leaving a `:HGblame` window. This pull request fixes this issue. The underlying problem is that `expand('<abuf>')` returns a string, for which `bufwinnr()` returns -1. By converting the result of `expand()`, resetting options when leaving the window works.